### PR TITLE
chore: add TravisCI support to be able to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+
+dist: trusty
+
+install:
+  - composer self-update
+  - composer install
+
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
once we have some unit tests by @CViniciusSDias (thanks man!) now it's time to add a CI, like TravisCI, to run `phpunit` on each new submitted PR.

@jansenfelipe you also have to enable TravisCI for this repo login with your GH account. it's free for open source projects 🎉  https://travis-ci.org/

future work: enable test coverage 💪 